### PR TITLE
Schema fixups

### DIFF
--- a/src/clj/pronto/schema.clj
+++ b/src/clj/pronto/schema.clj
@@ -78,9 +78,9 @@
     (if k
       (when-let [d (search-descriptors k descriptors)]
         (let [t (t/find-type clazz d)]
-          (if (w/protobuf-scalar? t)
-            (field-schema clazz d)
-            (struct-schema t (second (class-descriptors t []))))))
+          (if (u/struct? d)
+            (struct-schema t (second (class-descriptors t [])))
+            (field-schema clazz d))))
       (struct-schema clazz descriptors))))
 
 

--- a/src/clj/pronto/schema.clj
+++ b/src/clj/pronto/schema.clj
@@ -54,7 +54,7 @@
 (defn- struct-schema [clazz descriptors]
   (when (seq descriptors)
     (into
-     {}
+     (sorted-map)
      (map
       (fn [^Descriptors$FieldDescriptor fd]
         [(keyword


### PR DESCRIPTION
- show schema maps in sorted key order
- fix schema drill down for non-primitive leaf types