### PR TITLE
Remove any namespace qualified symbols in generated code

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -28,7 +28,8 @@
                                             [org.bitbucket.mstrobel/procyon-compilertools "0.5.36"]
                                             [org.openjdk.jol/jol-core "0.13"]
                                             [criterium "0.4.6"]
-                                            [com.clojure-goes-fast/clj-memory-meter "0.1.3"]]
+                                            [com.clojure-goes-fast/clj-memory-meter "0.1.3"]
+                                            [org.clojure/tools.analyzer.jvm "1.2.2"]]
                         :jvm-opts          ["-XX:-OmitStackTraceInFastThrow" "-Djdk.attach.allowAttachSelf"]
                         :aliases           {"clj-kondo" ["run" "-m" "clj-kondo.main"]}
                         :eftest            {:multithread?   false

--- a/test/pronto/tools_analyzer_test.clj
+++ b/test/pronto/tools_analyzer_test.clj
@@ -1,0 +1,14 @@
+(ns pronto.tools-analyzer-test
+  (:import (protogen.generated People$Person))
+  (:require [clojure.tools.analyzer.jvm :as ana]
+            [clojure.test :refer [deftest testing]]
+            [pronto.core :as p]))
+
+(deftest tools-analyzer-test
+  (testing "tools.analyzer should successfully analyze generated code"
+    ;; eval the form in order to avoid double class generation
+    (eval
+     '(do
+        (pronto.core/defmapper mapper [protogen.generated.People$Person])
+        (clojure.tools.analyzer.jvm/analyze
+            '(pronto.core/defmapper mapper [protogen.generated.People$Person]))))))


### PR DESCRIPTION
Closes #14 

This allows `tools.analyzer` to successfully analyze pronto generated code, fixing broken integration with `refactor-nrepl`.

Also added a test in order to guard against breakage in the future.