### PR TITLE
bump lein-protodeps

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -16,7 +16,7 @@
                                       :username :env/clojars_username
                                       :password :env/clojars_password}]]
 
-  :plugins [[com.appsflyer/lein-protodeps "1.0.1"]
+  :plugins [[com.appsflyer/lein-protodeps "1.0.5"]
             [lein-codox "0.10.7"]]
 
   :dependencies [[org.clojure/clojure "1.10.1"]


### PR DESCRIPTION
Thanks for the great library @nenorbot .  `./build_samples.sh` doesn't work on my m1 until I bump lein-protodeps.  I see you've already done the hard work and fixed the bug!