### PR TITLE
[skip ci] grand content write permissions to master ci job

### DIFF
--- a/.github/workflows/ci_master.yml
+++ b/.github/workflows/ci_master.yml
@@ -1,5 +1,8 @@
 name: "Release"
 
+permissions:
+  contents: write
+
 on:
   push:
     branches:


### PR DESCRIPTION
this MR when applied adds permissions to the master ci workflow to allow auto-tagging and push